### PR TITLE
Idea to automatically add listener and extension

### DIFF
--- a/bin/roave-no-leaks.php
+++ b/bin/roave-no-leaks.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\NoLeaks\CLI;
 
-use PHPUnit\TextUI\Command;
+use Roave\NoLeaks\PHPUnit\PHPUnitCommand;
 
 (function () {
     if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
@@ -15,5 +15,5 @@ use PHPUnit\TextUI\Command;
 
     $_SERVER['argv'][] = '--repeat=3';
 
-    Command::main();
+    PHPUnitCommand::main();
 })();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,11 @@
     verbose="true"
     executionOrder="random"
 >
+    <php>
+        <!-- to autoconfigure roave/no-leaks -->
+        <env name="REGISTER_NO_LEAKS" value="false" />
+    </php>
+
     <testsuites>
         <testsuite name="unit">
             <directory>./test/unit</directory>

--- a/src/PHPUnitCommand.php
+++ b/src/PHPUnitCommand.php
@@ -19,10 +19,9 @@ final class PHPUnitCommand extends Command
     protected function handleArguments(array $argv) : void
     {
         parent::handleArguments($argv);
-        if ($_ENV['REGISTER_NO_LEAKS'] ?? '' !== 'true') {
+        if (! $this->isAutoConfigureEnabled()) {
             return;
         }
-
         $this->arguments['listeners'] = array_merge(
             [new CollectTestExecutionMemoryFootprints()],
             $this->arguments['listeners'] ?? []
@@ -32,9 +31,14 @@ final class PHPUnitCommand extends Command
     protected function createRunner() : TestRunner
     {
         $testRunner = new TestRunner($this->arguments['loader']);
-        if ($_ENV['REGISTER_NO_LEAKS'] ?? '' === true) {
+        if ($this->isAutoConfigureEnabled()) {
             $testRunner->addExtension(new CollectTestExecutionMemoryFootprints());
         }
         return $testRunner;
+    }
+
+    protected function isAutoConfigureEnabled() : bool
+    {
+        return isset($_ENV['REGISTER_NO_LEAKS']) && $_ENV['REGISTER_NO_LEAKS'] === '1';
     }
 }

--- a/src/PHPUnitCommand.php
+++ b/src/PHPUnitCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\NoLeaks\PHPUnit;
+
+use PHPUnit\TextUI\Command;
+use PHPUnit\TextUI\TestRunner;
+use function array_merge;
+
+final class PHPUnitCommand extends Command
+{
+    public function run(array $argv, bool $exit = true) : int
+    {
+        // Should be improved
+        $this->arguments['listeners'] = array_merge([new CollectTestExecutionMemoryFootprints()], $this->arguments['listeners'] ?? []);
+        return parent::run($argv, $exit);
+    }
+
+    public static function main(bool $exit = true) : int
+    {
+        $command = new static();
+        return $command->run($_SERVER['argv'], $exit);
+    }
+
+    protected function createRunner() : TestRunner
+    {
+        $testRunner =  new TestRunner($this->arguments['loader']);
+        $testRunner->addExtension(new CollectTestExecutionMemoryFootprints());
+        return $testRunner;
+    }
+}


### PR DESCRIPTION
Hey Roave Team,

I think it could be nice to let 'no-leaks' autoconfigure / register itself into phpunit. 

This could happily help ci/travis configuration for multiple PHP versions. 

That way we don't need to have multiple phpunit.xml configs (a stage for php7.3 with listeners/extensions registered, earlier versions without).

This is just an idea to illustrate one possible way to do it, feel free to rename classes, improve or simply forget ;)



