### PR TITLE
Rename emptyTest into testMemoryBaselineWithEmptyTestBody

### DIFF
--- a/src/EmptyBaselineMemoryUsageTest.php
+++ b/src/EmptyBaselineMemoryUsageTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class EmptyBaselineMemoryUsageTest extends TestCase
 {
-    public const TEST_METHOD      = 'emptyTest';
+    public const TEST_METHOD      = 'testMemoryBaselineWithEmptyTestBody';
     private const ASSERTION_COUNT = 1;
 
     /**
@@ -23,7 +23,7 @@ final class EmptyBaselineMemoryUsageTest extends TestCase
      * Tests that deviate from this baseline pre/post memory usage are most
      * likely leaking.
      */
-    public function emptyTest() : void
+    public function testMemoryBaselineWithEmptyTestBody() : void
     {
         $this->addToAssertionCount(self::ASSERTION_COUNT);
     }

--- a/test/unit/CollectTestExecutionMemoryFootprintsTest.php
+++ b/test/unit/CollectTestExecutionMemoryFootprintsTest.php
@@ -190,7 +190,7 @@ MESSAGE
         $testSuite
             ->expects(self::once())
             ->method('addTest')
-            ->with(self::equalTo(new Baseline('emptyTest')));
+            ->with(self::equalTo(new Baseline('testMemoryBaselineWithEmptyTestBody')));
 
         (new CollectTestExecutionMemoryFootprints())->startTestSuite($testSuite);
     }

--- a/test/unit/EmptyBaselineMemoryUsageTest.php
+++ b/test/unit/EmptyBaselineMemoryUsageTest.php
@@ -20,7 +20,7 @@ final class EmptyBaselineMemoryUsageTest extends TestCase
         // intentional immediate value override - we're offsetting memory usage here, on purpose
         $memoryUsage = memory_get_usage();
 
-        $test->emptyTest();
+        $test->testMemoryBaselineWithEmptyTestBody();
 
         self::assertSame($memoryUsage, memory_get_usage());
         self::assertSame(1, $test->getNumAssertions());


### PR DESCRIPTION
Fixes https://github.com/Roave/no-leaks/issues/20