### PR TITLE
Added ext-xml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": "^7.3",
         "ext-json": "*",
+        "ext-xml": "*",
         "phpunit/phpunit": "^8.0.4"
     },
     "config": {


### PR DESCRIPTION
Composer throws an error while installation:
`squizlabs/php_codesniffer 3.5.3 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.`